### PR TITLE
Added employee permissions and improved admin site functionality

### DIFF
--- a/frontend/admin.py
+++ b/frontend/admin.py
@@ -1,10 +1,21 @@
 from django.contrib import admin
 from .models import ClientAccount, Car, Reservation, EmployeeAccount, AdminAccount, RentalLocation
+from .forms import ClientAccountForm
 
 # Register your models here.
-admin.site.register(ClientAccount)
 admin.site.register(Car)
 admin.site.register(Reservation)
 admin.site.register(EmployeeAccount)
 admin.site.register(AdminAccount)
 admin.site.register(RentalLocation)
+
+class ClientAccountAdmin(admin.ModelAdmin):
+    form = ClientAccountForm
+    list_display = ['user', 'get_email']
+
+    def get_email(self, obj):
+        return obj.user.email
+    get_email.admin_order_field = 'user__email'
+    get_email.short_description = 'Email Address'
+
+admin.site.register(ClientAccount, ClientAccountAdmin)

--- a/frontend/forms.py
+++ b/frontend/forms.py
@@ -2,7 +2,7 @@ from typing import Any
 from django import forms
 from django.contrib.auth.forms import UserCreationForm
 from django.contrib.auth.models import User
-from .models import Reservation
+from .models import Reservation, Client Account
 
 
 # Customize the user form to include fields for an email, first name, and last name
@@ -21,6 +21,7 @@ class UserRegisterForm(UserCreationForm):
         self.fields['password1'].widget.attrs['class'] = 'form-control'
         self.fields['password2'].widget.attrs['class'] = 'form-control'
 
+
 class ReservationForm(forms.ModelForm):
     rental_date = forms.DateTimeField(
         required=True,
@@ -37,3 +38,30 @@ class ReservationForm(forms.ModelForm):
     class Meta:
         model = Reservation
         fields = ["car", "username", "rental_date", "return_date"]
+
+
+class ClientAccountForm(forms.ModelForm):
+    username = forms.CharField(max_length=150)
+    password = forms.CharField(widget=forms.PasswordInput)
+    email = forms.EmailField(required=True)
+    first_name = forms.CharField(max_length=30, required=False)
+    last_name = forms.CharField(max_length=30, required=False)
+
+    class Meta:
+        model = ClientAccount
+        fields = ['username', 'password', 'email', 'first_name', 'last_name']
+
+    def save(self, commit=True):
+        user = User.objects.create_user(
+            username=self.cleaned_data['username'],
+            email=self.cleaned_data['email'],
+            password=self.cleaned_data['password'],
+            first_name=self.cleaned_data['first_name'],
+            last_name=self.cleaned_data['last_name']
+        )
+        client_account = super(ClientAccountForm, self).save(commit=False)
+        client_account.user = user
+        if commit:
+            client_account.save()
+        return client_account
+

--- a/frontend/models.py
+++ b/frontend/models.py
@@ -35,7 +35,7 @@ class Reservation(models.Model):
 
       
 class EmployeeAccount(models.Model):
-    username = models.CharField(max_length=20)
+    username = models.CharField(max_length=20, unique=True)
     password = models.CharField(max_length=20)
     first_name = models.CharField(max_length=100)
     last_name = models.CharField(max_length=100)
@@ -43,6 +43,27 @@ class EmployeeAccount(models.Model):
 
     def __str__(self):
         return self.first_name + ' ' + self.last_name
+
+    # https://docs.djangoproject.com/en/5.0/ref/models/instances/
+    def save(self, *args, **kwargs):
+        if not self.pk:
+            # Create a new user object if this is a new employee
+            user = User.objects.create_user(
+                username=self.username,
+                email=self.email,
+                password=self.password,
+                first_name=self.first_name,
+                last_name=self.last_name
+            )
+        else:
+            # Update existing user details if this employee already exists
+            user = User.objects.get(username=self.username)
+            user.email = self.email
+            user.first_name = self.first_name
+            user.last_name = self.last_name
+            user.set_password(self.password)
+            user.save()
+        super().save(*args, **kwargs)
 
 
 class AdminAccount(models.Model):


### PR DESCRIPTION
This pull request requires that a group is made in the admin page called “Employees”. This group can then be assigned all the permissions with the label “car”, “client account”, and “reservation”. The admin site functionality has also been improved in which an admin user can create an employee account in the employee account section of the admin page, and that account will be automatically added to the Users list. The admin must go to the Users list and click the username of the employee account they created. From there, the admin turns on staff status and assigns them to the Employees group for the appropriate permissions. When the employee signs in, they are directed to the admin page where can view, add, change, and delete cars, client accounts, and reservations, and these updates will show up on the admin user's perspective as well. These permissions differ from admin users who have access to those elements along with access to rental location assignments, employee and admin accounts, all users and groups, and permissions.